### PR TITLE
Fixed inability to set valid fan level

### DIFF
--- a/evox2_ec.c
+++ b/evox2_ec.c
@@ -219,7 +219,7 @@ static ssize_t fan_level_store(struct device *dev,
     struct ec_fan *fan = dev_get_drvdata(dev);
     u8 val;
 
-    if (!kstrtou8(buf, 10, &val))
+    if (kstrtou8(buf, 10, &val))
         return -EINVAL;
 
     write_fan_level(fan, val);


### PR DESCRIPTION
Apparently, `kstrtou8()` returns 0 on success so the logic was reversed.