### PR TITLE
fixed building with sudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ default: modules
 
 .PHONY: modules
 modules:
-	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) modules
+	$(MAKE) -C $(KERNEL_BUILD) M=$(shell pwd) modules
 
 .PHONY: modules_install
 modules_install: modules
-	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) modules_install
+	$(MAKE) -C $(KERNEL_BUILD) M=$(shell pwd) modules_install
 
 .PHONY: clean
 clean:
-	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) clean
+	$(MAKE) -C $(KERNEL_BUILD) M=$(shell pwd) clean
 	rm -rf $(BUILD_DIR)
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,22 @@
 KERNEL_BUILD ?= /lib/modules/$(shell uname -r)/build
 MODULE_NAME := ec_su_axb35.ko
 MODULE_INSTALLED_PATH := $(shell modinfo -n $(basename $(MODULE_NAME)) 2>/dev/null)
+PWD := $(CURDIR)
 
 .PHONY: default
 default: modules
 
 .PHONY: modules
 modules:
-	$(MAKE) -C $(KERNEL_BUILD) M=$(shell pwd) modules
+	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) modules
 
 .PHONY: modules_install
 modules_install: modules
-	$(MAKE) -C $(KERNEL_BUILD) M=$(shell pwd) modules_install
+	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) modules_install
 
 .PHONY: clean
 clean:
-	$(MAKE) -C $(KERNEL_BUILD) M=$(shell pwd) clean
+	$(MAKE) -C $(KERNEL_BUILD) M=$(PWD) clean
 	rm -rf $(BUILD_DIR)
 
 .PHONY: install


### PR DESCRIPTION
So `@TechnigmaAI` on Discord came to me with the problem that the module cannot be built on Ubuntu 24.04.

I tried to help him, but he was just getting completely random errors all the time, so I installed a clean 24.04 and eventually managed to reproduce the problem with his help.

Turned out that `sudo` is to blame. Running `sudo make` or `sudo make install` **mangles the kernel sources** and makes them unusable for any further compilation. Sounds insane, but apparently the environment under `sudo` leads to exactly this.

After more digging and googling a found a solution which seems to work fine in all combinations (`make` under user, `sudo make` and `make` under root).