### PR TITLE
Reset all fans to AUTO mode before unloading module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Vendors using that board:
   - FEVM FA-EX9
   - Peladn YO1
   - NIMO AI MiniPC
+  - Corsair AI Workstation 300
 
 An update to date list can be found [here](https://strixhalo-homelab.d7.wtf/Hardware/Boards/Sixunited-AXB35)
 

--- a/src/ec_su_axb35.c
+++ b/src/ec_su_axb35.c
@@ -595,6 +595,31 @@ static int __init ec_su_axb35_init(void)
 static void __exit ec_su_axb35_exit(void)
 {
     int i;
+
+    /* Reset all fans to AUTO mode before unloading */
+    for (i = 0; i < ARRAY_SIZE(ec_fans); i++) {
+        struct ec_fan *fan = &ec_fans[i];
+        u8 val;
+
+        fan->mode = AUTO;
+
+        switch (fan->mode_reg) {
+        case 0x21: // Fan 1
+            val = 0x10;
+            break;
+        case 0x23: // Fan 2
+            val = 0x20;
+            break;
+        case 0x25: // Fan 3
+            val = 0x30;
+            break;
+        default:
+            continue;
+        }
+        ec_write(fan->mode_reg, val);
+        pr_info("ec_su_axb35: %s reset to AUTO mode\n", fan->name);
+    }
+
     for (i = 0; i < ARRAY_SIZE(ec_fans); i++) {
         if (!IS_ERR(ec_fans[i].dev)) {
             device_remove_file(ec_fans[i].dev, &dev_attr_fan_rpm);


### PR DESCRIPTION
## Reset all fans to AUTO mode before unloading module

Before this fix, if the kernel module was unloaded (e.g. dkms failing to compile or the system rebooted) while the fan was to `CURVE` mode, the EC hardware remained in that state with no automatic fan control.

This could lead to poor cooling and potentially even further damage in extreme cases, since the fan control depends on this kernel module when not set to AUTO.

There's a particularly telling case below, where the user doesn't realise that the module is not loaded, his fans are set to CURVE, and his system freezes repeatedly with the system reaching, quote:  
> measured 184 W FAST against a 120 W limit, 111 °C against a 98 °C tctl limit.
  
This was reproduced by the user on three different Corsair AI Workstation 300 machines: https://github.com/hogeheer499-commits/strix-halo-guide/issues/24 
He later realises that the module was not loaded, rectifies the problem, and the issue goes away:

> modprobe: FATAL: Module ec_su_axb35 not found
> ...
> This matters because the driver’s curve mode is active software control: a kernel work loop reads the EC temperature and adjusts fan levels every second. If the module is absent, that custom curve is not running.

You can test this behaviour by setting one of your fans to CURVE and then reloading the module:

```
echo 'curve' | sudo tee /sys/class/ec_su_axb35/fan3/mode
rmmod ec_su_axb35; sleep 1; modprobe ec_su_axb35;
cat /sys/class/ec_su_axb35/fan3/mode
```

Observe that the fan mode setting sticks.

With this change the exit handler resets all fans to AUTO mode before unloading, so the EC always returns to safe automatic control before the driver is removed.

I have tested the change on my own Corsair AI Workstation 300, and it's working reliably: 

```
❯ journalctl -b -k -g ec_su_axb35
Jul 20 00:33:31 Optiplex kernel: ec_su_axb35: Sixunited AXB35-02 EC driver loaded
Jul 20 00:46:56 Optiplex kernel: ec_su_axb35: Module unloaded
Jul 20 00:46:57 Optiplex kernel: ec_su_axb35: Sixunited AXB35-02 EC driver loaded
Jul 20 01:06:17 Optiplex kernel: ec_su_axb35: Module unloaded
Jul 20 01:06:18 Optiplex kernel: ec_su_axb35: Sixunited AXB35-02 EC driver loaded
Jul 20 01:06:33 Optiplex kernel: ec_su_axb35: fan1 reset to AUTO mode
Jul 20 01:06:33 Optiplex kernel: ec_su_axb35: fan2 reset to AUTO mode
Jul 20 01:06:33 Optiplex kernel: ec_su_axb35: fan3 reset to AUTO mode
Jul 20 01:06:33 Optiplex kernel: ec_su_axb35: Module unloaded
Jul 20 01:06:34 Optiplex kernel: ec_su_axb35: Sixunited AXB35-02 EC driver loaded
```

Please let me know if you'd like any changes made to this PR, I realise the logging is a bit verbose. Thanks -R