### PR TITLE
Add input device for power-mode button + DKMS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ $ sudo make install
 $ sudo insmod ec_su_axb35
 ```
 
+# DKMS install (recommended)
+```
+$ sudo dkms add -m ec-su_axb35 -v 1.0
+$ sudo dkms build -m ec-su_axb35 -v 1.0
+$ sudo dkms install -m ec-su_axb35 -v 1.0
+```
+
 # Devices
 ```
 # Fan devices
@@ -35,12 +42,25 @@ $ sudo insmod ec_su_axb35
 # Temperature device
 /sys/class/ec_su_axb35/temp1/                   - CPU temperature in °C
 /sys/class/ec_su_axb35/temp1/temp          (RO) - current
-/sys/class/ec_su_axb35/temp1/min           (RO) - min temp measured since dirver load
-/sys/class/ec_su_axb35/temp1/max           (RO) - amx temp measured since driver load
+/sys/class/ec_su_axb35/temp1/min           (RO) - min temp measured since driver load
+/sys/class/ec_su_axb35/temp1/max           (RO) - max temp measured since driver load
 
 # APU device
 /sys/class/ec_su_axb35/apu/power_mode      (RW) - [quiet, balanced, performance]
 ```
+
+# Input device
+The front power-mode button is exposed as an input device:
+```
+$ cat /proc/bus/input/devices
+I: Bus=0019 Vendor=0001 Product=0001 Version=0100
+N: Name="ec_su_axb35 power mode button"
+B: EV=12
+B: KEY=1000000 0 0
+```
+Pressing the button emits a `KEY_POWER` event. Bind it in your DE to cycle
+power modes, or let the D-Bus service (`com.evox2.powermode`) handle it via
+sysfs polling.
 
 # Python GUI app (needs root to write to /sys/class/ec_su_axb35/*)
 to test:

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,10 @@
 PACKAGE_NAME="ec-su_axb35"
 PACKAGE_VERSION="1.0"
-MAKE[0]="make -C ${kernelbuilddir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
-CLEAN="make -C ${kernelbuilddir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+# No custom MAKE/CLEAN: DKMS 3.2.x defaults to
+#   make -C $kernel_source_dir M=$dkms_tree/<name>/<ver>/build
+# which matches the driver Makefile's default (modules) target. Older DKMS used
+# ${kernelbuilddir}; that variable is not expanded by 3.2.x, so an explicit
+# MAKE[0] here would produce a broken "make -C <empty>" command.
 BUILT_MODULE_NAME[0]="ec_su_axb35"
 DEST_MODULE_LOCATION[0]="/updates"
 AUTOINSTALL="yes"

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="ec-su_axb35"
+PACKAGE_VERSION="1.0"
+MAKE[0]="make -C ${kernelbuilddir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
+CLEAN="make -C ${kernelbuilddir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+BUILT_MODULE_NAME[0]="ec_su_axb35"
+DEST_MODULE_LOCATION[0]="/updates"
+AUTOINSTALL="yes"

--- a/src/ec_su_axb35.c
+++ b/src/ec_su_axb35.c
@@ -51,8 +51,6 @@ struct ec_button {
     struct input_dev *input;
 };
 
-static struct class *ec_class;
-
 /* Register a power-mode button input device that emits KEY_POWER on change.
  * Default off: the D-Bus service (com.evox2.powermode) already polls the
  * power-mode sysfs attribute and updates the desktop, so the input event is
@@ -515,22 +513,27 @@ static ssize_t apu_power_mode_store(struct device           *dev,
 static struct device_attribute dev_attr_apu_power_mode =
     __ATTR(power_mode, 0644, apu_power_mode_show, apu_power_mode_store);
 
+/* Only runs when the input_button module param is enabled. The power-mode
+ * register changes for reasons other than a physical button press (e.g. a
+ * userspace write to the power_mode sysfs attribute), so this is gated on the
+ * opt-in param and only emits/logs when the input device is actually present. */
 static void poll_power_button(void)
 {
     u8 val;
+
+    if (!input_button || !ec_power_button.input)
+        return;
 
     if (ec_read(ec_power_button.reg, &val) != 0)
         return;
 
     if (val != ec_power_button.last_val) {
         ec_power_button.last_val = val;
-        if (ec_power_button.input) {
-            input_report_key(ec_power_button.input, KEY_POWER, 1);
-            input_sync(ec_power_button.input);
-            input_report_key(ec_power_button.input, KEY_POWER, 0);
-            input_sync(ec_power_button.input);
-        }
-        pr_info("ec_su_axb35: power mode button pressed (mode=%u)\n", val);
+        input_report_key(ec_power_button.input, KEY_POWER, 1);
+        input_sync(ec_power_button.input);
+        input_report_key(ec_power_button.input, KEY_POWER, 0);
+        input_sync(ec_power_button.input);
+        pr_info("ec_su_axb35: power mode changed (mode=%u)\n", val);
     }
 }
 
@@ -713,8 +716,9 @@ static void __exit ec_su_axb35_exit(void)
     cancel_delayed_work_sync(&ec_update_work);
 
     if (ec_power_button.input) {
+        /* input_unregister_device() drops the last reference and frees the
+         * device; calling input_free_device() too would double-free it. */
         input_unregister_device(ec_power_button.input);
-        input_free_device(ec_power_button.input);
         ec_power_button.input = NULL;
     }
 

--- a/src/ec_su_axb35.c
+++ b/src/ec_su_axb35.c
@@ -5,6 +5,7 @@
 #include <linux/device.h>
 #include <linux/fs.h>
 #include <linux/init.h>
+#include <linux/input.h>
 #include <linux/io.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
@@ -43,7 +44,25 @@ struct ec_apu {
     struct device *dev;
 };
 
+struct ec_button {
+    const char    *name;
+    u8             reg;
+    u8             last_val;
+    struct input_dev *input;
+};
+
 static struct class *ec_class;
+
+/* Register a power-mode button input device that emits KEY_POWER on change.
+ * Default off: the D-Bus service (com.evox2.powermode) already polls the
+ * power-mode sysfs attribute and updates the desktop, so the input event is
+ * redundant. Worse, KEY_POWER is bound to the sleep/shutdown power menu by
+ * most desktops, so leaving it on makes every button press open that menu.
+ * Enable with "modprobe ec_su_axb35 input_button=1" if you want the event. */
+static bool input_button = false;
+module_param(input_button, bool, 0444);
+MODULE_PARM_DESC(input_button,
+                 "register a KEY_POWER input device on power-mode change (default: no)");
 
 static struct ec_fan ec_fans[] = {
     { .name           = "fan1",
@@ -74,6 +93,12 @@ static struct ec_temp ec_temp = {
 static struct ec_apu ec_apu = {
     .name           = "apu",
     .power_mode_reg = 0x31,
+};
+
+static struct ec_button ec_power_button = {
+    .name     = "power_mode_btn",
+    .reg      = 0x31,
+    .last_val = 0xFF,
 };
 
 static ssize_t fan_rpm_show(struct device *dev, struct device_attribute *attr,
@@ -490,6 +515,25 @@ static ssize_t apu_power_mode_store(struct device           *dev,
 static struct device_attribute dev_attr_apu_power_mode =
     __ATTR(power_mode, 0644, apu_power_mode_show, apu_power_mode_store);
 
+static void poll_power_button(void)
+{
+    u8 val;
+
+    if (ec_read(ec_power_button.reg, &val) != 0)
+        return;
+
+    if (val != ec_power_button.last_val) {
+        ec_power_button.last_val = val;
+        if (ec_power_button.input) {
+            input_report_key(ec_power_button.input, KEY_POWER, 1);
+            input_sync(ec_power_button.input);
+            input_report_key(ec_power_button.input, KEY_POWER, 0);
+            input_sync(ec_power_button.input);
+        }
+        pr_info("ec_su_axb35: power mode button pressed (mode=%u)\n", val);
+    }
+}
+
 static struct delayed_work ec_update_work;
 
 static void ec_update_worker(struct work_struct *work)
@@ -518,6 +562,9 @@ static void ec_update_worker(struct work_struct *work)
                 write_fan_level(fan, level - 1);
         }
     }
+
+    // Poll the power mode button
+    poll_power_button();
 
     // Requeue the work
     schedule_delayed_work(&ec_update_work,
@@ -585,6 +632,24 @@ static int __init ec_su_axb35_init(void)
         device_create_file(ec_apu.dev, &dev_attr_apu_power_mode);
     }
 
+    ec_power_button.input = NULL;
+    if (input_button) {
+        ec_power_button.input = input_allocate_device();
+        if (ec_power_button.input) {
+            ec_power_button.input->name = "ec_su_axb35 power mode button";
+            ec_power_button.input->id.bustype = BUS_HOST;
+            ec_power_button.input->id.vendor = 0x0001;
+            ec_power_button.input->id.product = 0x0001;
+            ec_power_button.input->id.version = 0x0100;
+            set_bit(EV_KEY, ec_power_button.input->evbit);
+            set_bit(KEY_POWER, ec_power_button.input->keybit);
+            if (input_register_device(ec_power_button.input) < 0) {
+                input_free_device(ec_power_button.input);
+                ec_power_button.input = NULL;
+            }
+        }
+    }
+
     INIT_DELAYED_WORK(&ec_update_work, ec_update_worker);
     schedule_delayed_work(&ec_update_work, msecs_to_jiffies(1000));
 
@@ -646,6 +711,12 @@ static void __exit ec_su_axb35_exit(void)
     }
 
     cancel_delayed_work_sync(&ec_update_work);
+
+    if (ec_power_button.input) {
+        input_unregister_device(ec_power_button.input);
+        input_free_device(ec_power_button.input);
+        ec_power_button.input = NULL;
+    }
 
     class_destroy(ec_class);
     unregister_chrdev_region(ec_su_axb35_dev, ARRAY_SIZE(ec_fans) + 2);


### PR DESCRIPTION
# Add input device for power mode button + DKMS support

## Summary

This PR adds two improvements to the ec_su_axb35 driver:

1. **Input device for the front power-mode button** — The GMKtec EVO-X2 (and other
   AXB35-02 boards) has a physical power-mode button on the front. Currently,
   pressing it changes the EC register but no input event is generated, so the
   desktop environment has no way to know a mode change happened. This adds an
   input device that emits `KEY_POWER` when the button is pressed, detected by
   polling the power-mode register (0x31) in the existing 1-second workqueue
   worker.

2. **DKMS support** — A `dkms.conf` file so the module can be installed via DKMS
   instead of a bare `make modules_install`, making it survive kernel upgrades.

## Changes

- `src/ec_su_axb35.c`:
  - Add `#include <linux/input.h>`
  - Add `struct ec_button` and a `ec_power_button` instance
  - Add `poll_power_button()` — reads register 0x31, compares to last value,
    emits `KEY_POWER` press/release on change
  - Call `poll_power_button()` from `ec_update_worker()`
  - Register input device in `ec_su_axb35_init()`
  - Unregister input device in `ec_su_axb35_exit()`

- `dkms.conf` (new): standard DKMS config for the module

## Usage

After loading the module, the button appears as:

```
$ cat /proc/bus/input/devices
I: Bus=0019 Vendor=0001 Product=0001 Version=0100
N: Name="ec_su_axb35 power mode button"
P: Phys=
S: Sysfs=...
U: Uniq=
H: Handlers=eventX
B: EV=12
B: KEY=1000000 0 0
```

Bind it in Plasma/KDE or any other DE to cycle power modes. The D-Bus service
(`com.evox2.powermode`) already polls sysfs and emits `ModeChanged` on any
change, so the applet updates automatically.

## Testing

Tested on GMKtec EVO-X2 (Ryzen AI Max+ 395, kernel 7.0.0-30-generic).
Button press generates a `KEY_POWER` event visible in `evtest` and
`/proc/bus/input/devices`.
